### PR TITLE
PHP8 support

### DIFF
--- a/platformsh-laravel-env.php
+++ b/platformsh-laravel-env.php
@@ -93,7 +93,7 @@ function mapAppUrl(Config $config) : void
         return;
     }
 
-    $requestUrl = chr(0);
+    $requestUrl = false;
     if (isset($_SERVER['SERVER_NAME'])) {
         $requestUrl = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on' ? 'https://' : 'http://')
             . $_SERVER['SERVER_NAME'];

--- a/platformsh-laravel-env.php
+++ b/platformsh-laravel-env.php
@@ -93,7 +93,7 @@ function mapAppUrl(Config $config) : void
         return;
     }
 
-    $requestUrl = false;
+    $requestUrl = chr(0);
     if (isset($_SERVER['SERVER_NAME'])) {
         $requestUrl = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on' ? 'https://' : 'http://')
             . $_SERVER['SERVER_NAME'];


### PR DESCRIPTION
The usage of strpos breaks with PHP8. This tries with minimal changes to keep the existing functionality while ensuring we don't break while on php8