### PR TITLE
changes default for requestUrl from boolean false to empty string

### DIFF
--- a/platformsh-laravel-env.php
+++ b/platformsh-laravel-env.php
@@ -93,7 +93,7 @@ function mapAppUrl(Config $config) : void
         return;
     }
 
-    $requestUrl = false;
+    $requestUrl = '';
     if (isset($_SERVER['SERVER_NAME'])) {
         $requestUrl = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on' ? 'https://' : 'http://')
             . $_SERVER['SERVER_NAME'];


### PR DESCRIPTION
v8.0.0 of PHP no longer accepts anything other than a string for needle. Previously (<8.0.0), anything else would be converted to an int and then value of `chr(int)` would be used. Changes the default value for `$requestUrl` from boolean false to empty string.

 Closes #17