### PR TITLE
Laravel 7+ renamed MAIL_DRIVER to MAIL_MAILER

### DIFF
--- a/platformsh-laravel-env.php
+++ b/platformsh-laravel-env.php
@@ -161,6 +161,7 @@ function mapPlatformShMail(Config $config) : void
     }
 
     setEnvVar('MAIL_DRIVER', 'smtp');
+    setEnvVar('MAIL_MAILER', 'smtp'); // From laravel 7 onwards MAIL_DRIVER is renamed to MAIL_MAILER
     setEnvVar('MAIL_HOST', $config->smtpHost);
     setEnvVar('MAIL_PORT', '25');
     setEnvVar('MAIL_ENCRYPTION', '0');


### PR DESCRIPTION
Laravel 7+ compatibility added
Without this, email cannot be sent and you'll get a swiftmailer  error
`Swift_TransportException  Expected response code 220 but got an empty response`