### PR TITLE
Custom MAIL environment variables being overwritten when Outgoing mail is disabled.

### DIFF
--- a/platformsh-laravel-env.php
+++ b/platformsh-laravel-env.php
@@ -17,7 +17,7 @@ mapPlatformShEnvironment();
 function mapPlatformShEnvironment() : void
 {
     $config = new Config();
-
+    
     if (!$config->inRuntime()) {
         return;
     }
@@ -156,7 +156,7 @@ function mapPlatformShRedisSession(string $relationshipName, Config $config) : v
 
 function mapPlatformShMail(Config $config) : void
 {
-    if (!isset($config->smtpHost)) {
+    if (empty($config->smtpHost)) {
         return;
     }
 

--- a/platformsh-laravel-env.php
+++ b/platformsh-laravel-env.php
@@ -17,7 +17,7 @@ mapPlatformShEnvironment();
 function mapPlatformShEnvironment() : void
 {
     $config = new Config();
-    
+
     if (!$config->inRuntime()) {
         return;
     }

--- a/tests/LaravelBridgeMailTest.php
+++ b/tests/LaravelBridgeMailTest.php
@@ -45,4 +45,49 @@ class LaravelBridgeMailTest extends TestCase
         $this->assertEquals('25', getenv('MAIL_PORT'));
         $this->assertEquals('0', getenv('MAIL_ENCRYPTION'));
     }
+
+    /**
+     * Test if the project has been instructed to disable Platform's own SMTP proxy
+     * 
+     * @return void
+     */
+    public function test_disabled_mail() : void
+    {
+        $smtpHost = 'smtp.external-service.com';
+        $smtpPort = '587';
+        $smtpMailer = 'sendmail';
+        $smtpEncyption = 'tls';
+
+        putenv('PLATFORM_APPLICATION_NAME=test');
+        putenv('PLATFORM_ENVIRONMENT=test');
+        putenv('PLATFORM_PROJECT_ENTROPY=test');
+        putenv('MAIL_HOST=' . $smtpHost);
+        putenv('MAIL_MAILER=' . $smtpMailer);
+        putenv('MAIL_PORT=' . $smtpPort);
+        putenv('MAIL_ENCRYPTION=' . $smtpEncyption);
+        $this->loadDummyRoutes();
+
+        /**
+         * https://support.platform.sh/hc/en-us/articles/12055076033810-Email-SMTP-sending-details
+         * There is mixed information on the value of PLATFORM_SMTP_HOST the above support ticket 
+         * states When outgoing emails are off, the variable is empty
+         * Debugging on an instance shows it's set to false.
+         * 
+         * These assertions test both senarios
+         */
+        putenv(sprintf('PLATFORM_SMTP_HOST=%s', ''));
+        mapPlatformShEnvironment();
+        $this->assertEquals($smtpHost, getenv('MAIL_HOST'));
+        $this->assertEquals($smtpMailer, getenv('MAIL_MAILER'));
+        $this->assertEquals($smtpPort, getenv('MAIL_PORT'));
+        $this->assertEquals($smtpEncyption, getenv('MAIL_ENCRYPTION'));
+
+        putenv(sprintf('PLATFORM_SMTP_HOST=%s', false));
+        mapPlatformShEnvironment();
+        $this->assertEquals($smtpHost, getenv('MAIL_HOST'));
+        $this->assertEquals($smtpMailer, getenv('MAIL_MAILER'));
+        $this->assertEquals($smtpPort, getenv('MAIL_PORT'));
+        $this->assertEquals($smtpEncyption, getenv('MAIL_ENCRYPTION'));
+
+    }
 }


### PR DESCRIPTION
We experienced a bug where the environment variables set in Platform.sh for the project's environment were being ignored when outgoing emails using P.sh's own SendGrid SMTP host.

The [documentation](https://support.platform.sh/hc/en-us/articles/12055076033810-Email-SMTP-sending-details) says that disabling email through the project's settings UI sets the value of PLATFORM_SMTP_HOST to an empty string.  Though testing on the instance suggests that the value is set to `false`. 

Either way, the check previously was only looking at the existence of the config variable which meant project environment vars were always being overwritten with defaults set in the `mapPlatformShMail` function even when the values were not set.

I've switched the check to use `empty()` which allows the custom environment variables to be set correctly.