### PR TITLE
Update platformsh/config-reader to ^3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=7.2",
-        "platformsh/config-reader": "^2.4.0"
+        "platformsh/config-reader": "^3.0"
     },
     "autoload": {
         "files": ["platformsh-laravel-env.php"]


### PR DESCRIPTION
 ## Summary
  Updates the `platformsh/config-reader` dependency from `^2.4.0` to `^3.0` to resolve PHP deprecation
  warnings.

  ## Changes
  - Bumps `platformsh/config-reader` to `^3.0`

  ## Motivation
  Fixes PHP deprecation warnings that were appearing in version 2.4.0:

  Deprecated: Platformsh\ConfigReader\Config::__construct(): Implicitly marking parameter
  $environmentVariables as nullable is deprecated, the explicit nullable type must be used instead in
  /var/www/html/vendor/platformsh/config-reader/src/Config.php on line 152

  Deprecated: Platformsh\ConfigReader\Config::getUpstreamRoutes(): Implicitly marking parameter $appName
   as nullable is deprecated, the explicit nullable type must be used instead in
  /var/www/html/vendor/platformsh/config-reader/src/Config.php on line 340

  Version 3.0 resolves these deprecation warnings by using explicit nullable type declarations.